### PR TITLE
Added status_code numeric field

### DIFF
--- a/plugins/telegraf_pfifgw.php
+++ b/plugins/telegraf_pfifgw.php
@@ -97,6 +97,7 @@ foreach ($gw_array as $gw => $gateway) {
     $stddev = $gw_statuses[$gw]["stddev"];
     $loss = $gw_statuses[$gw]["loss"];
     $status = $gw_statuses[$gw]["status"];
+    $status_code;
     $substatus;
 
     $interface = $gateway["interface"];
@@ -122,6 +123,11 @@ foreach ($gw_array as $gw => $gateway) {
     }
     if (!isset($status)) {
         $status = "Unavailable";
+        $status_code = "2";
+    } elseif ($status == "online") {
+        $status_code = "0";
+    } elseif ($status == "down") {
+        $status_code = "1";
     }
     if (!isset($interface)) {
         $interface = "Unassigned";
@@ -154,7 +160,7 @@ foreach ($gw_array as $gw => $gateway) {
     }
 
     printf(
-        "gateways,host=%s,interface=%s,gateway_name=%s monitor=\"%s\",source=\"%s\",defaultgw=%s,gwdescr=\"%s\",delay=%s,stddev=%s,loss=%s,status=\"%s\",substatus=\"%s\"\n",
+        "gateways,host=%s,interface=%s,gateway_name=%s monitor=\"%s\",source=\"%s\",defaultgw=%s,gwdescr=\"%s\",delay=%s,stddev=%s,loss=%s,status=\"%s\",status_code=%d,substatus=\"%s\"\n",
         $host,
         $interface,
         $name, //name is required as it is possible to have 2 gateways on 1 interface.  i.e. WAN_DHCP and WAN_DHCP6
@@ -166,6 +172,7 @@ foreach ($gw_array as $gw => $gateway) {
         floatval($stddev),
         floatval($loss),
         $status,
+        $status_code,
         $substatus
     );
 };


### PR DESCRIPTION
Since Grafana only uses numbers for threshold formatting, I've added a "status code" to the GW status. This allows you to do conditional formatting for the GW to easily display wither it's up or down. I haven't made any changes to the map itself since my use case is rather different from the default, but essentially what I'm doing is adding a value mapping for 0, 1, and 2 and then creating overrides for that field to set the background color based on the predetermined thresholds. 

New status codes are 0=online, 1=down, and 2=unavailable.

